### PR TITLE
Addition of Bro Intel Framework as an output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ IOC Parser is a tool to extract indicators of compromise from security reports i
 * *FILE* File/directory path to report(s)
 * *-p INI* Pattern file
 * *-i FORMAT* Input format (pdf/txt/html)
-* *-o FORMAT* Output format (csv/json/yara)
+* *-o FORMAT* Output format (csv/json/yara/bro)
 * *-d* Deduplicate matches
 * *-l LIB* Parsing library
 

--- a/ioc-parser.py
+++ b/ioc-parser.py
@@ -283,7 +283,7 @@ if __name__ == "__main__":
     argparser.add_argument('PATH', action='store', help='File/directory/URL to report(s)')
     argparser.add_argument('-p', dest='INI', default=os.path.join(os.path.dirname(os.path.abspath(__file__)), 'patterns.ini'), help='Pattern file')
     argparser.add_argument('-i', dest='INPUT_FORMAT', default='pdf', help='Input format (pdf/txt)')
-    argparser.add_argument('-o', dest='OUTPUT_FORMAT', default='csv', help='Output format (csv/json/yara)')
+    argparser.add_argument('-o', dest='OUTPUT_FORMAT', default='csv', help='Output format (csv/json/yara/bro)')
     argparser.add_argument('-d', dest='DEDUP', action='store_true', default=False, help='Deduplicate matches')
     argparser.add_argument('-l', dest='LIB', default='pdfminer', help='PDF parsing library (pypdf2/pdfminer)')
     args = argparser.parse_args()

--- a/output.py
+++ b/output.py
@@ -3,7 +3,7 @@ import sys
 import csv
 import json
 
-OUTPUT_FORMATS = ('csv', 'json', 'yara', )
+OUTPUT_FORMATS = ('csv', 'json', 'yara', 'bro',)
 
 def getHandler(output_format):
     output_format = output_format.lower()
@@ -92,3 +92,14 @@ class OutputHandler_yara(OutputHandler):
         print("\tcondition:")
         print("\t\t" + cond)
         print("}")
+
+class OutputHandler_bro(OutputHandler):    
+    # Acceptable Bro Intel types - Intel::ADDR/Intel::URL/Intel::SOFTWARE/Intel::EMAIL/Intel::DOMAIN/Intel::USER_NAME/Intel::FILE_HASH/Intel::FILE_NAME/Intel::CERT_HASH
+    def print_header(self, fpath):
+        print("#fields indicator\tindicator_type\tmeta.source\tmeta.url\tmeta.do_notice\tmeta.if_in")
+    
+    def print_match(self, fpath, page, name, match):
+        print("Type: " + name)
+
+        
+        

--- a/output.py
+++ b/output.py
@@ -108,9 +108,6 @@ class OutputHandler_bro(OutputHandler):
             "Filename": "Intel::FILE_NAME",
         })
 
-    def print_header(self, fpath):
-        print("#fields indicator\tindicator_type\tmeta.source\tmeta.url\tmeta.do_notice\tmeta.if_in")
-    
     def print_match(self, fpath, page, name, match):
         source_name = os.path.splitext(os.path.basename(fpath))[0].translate(self.rule_enc)
         

--- a/output.py
+++ b/output.py
@@ -108,7 +108,10 @@ class OutputHandler_bro(OutputHandler):
             "Filename": "Intel::FILE_NAME",
         })
 
-    def print_match(self, fpath, name, match):
+    def print_header(self, fpath):
+        print("#fields indicator\tindicator_type\tmeta.source\tmeta.url\tmeta.do_notice\tmeta.if_in")
+    
+    def print_match(self, fpath, page, name, match):
         source_name = os.path.splitext(os.path.basename(fpath))[0].translate(self.rule_enc)
         
         if name in self.intel_types:

--- a/output.py
+++ b/output.py
@@ -108,10 +108,7 @@ class OutputHandler_bro(OutputHandler):
             "Filename": "Intel::FILE_NAME",
         })
 
-    def print_header(self, fpath):
-        print("#fields indicator\tindicator_type\tmeta.source\tmeta.url\tmeta.do_notice\tmeta.if_in")
-    
-    def print_match(self, fpath, page, name, match):
+    def print_match(self, fpath, name, match):
         source_name = os.path.splitext(os.path.basename(fpath))[0].translate(self.rule_enc)
         
         if name in self.intel_types:

--- a/output.py
+++ b/output.py
@@ -94,12 +94,24 @@ class OutputHandler_yara(OutputHandler):
         print("}")
 
 class OutputHandler_bro(OutputHandler):    
-    # Acceptable Bro Intel types - Intel::ADDR/Intel::URL/Intel::SOFTWARE/Intel::EMAIL/Intel::DOMAIN/Intel::USER_NAME/Intel::FILE_HASH/Intel::FILE_NAME/Intel::CERT_HASH
+    def __init__(self):
+        self.rule_enc = ''.join(chr(c) if chr(c).isupper() or chr(c).islower() or chr(c).isdigit() else '_' for c in range(256))
+
+        intel_types = dict({
+            "IP": "Intel::ADDR",
+            "URL": "Intel::URL",
+            "Email": "Intel::EMAIL",
+            "Host": "Intel::DOMAIN",
+            "MD5": "Intel::FILE_HASH",
+            "SHA1": "Intel::FILE_HASH",
+            "SHA256": "Intel::FILE_HASH",
+            "Filename": "Intel::FILE_NAME",
+        })
+
     def print_header(self, fpath):
         print("#fields indicator\tindicator_type\tmeta.source\tmeta.url\tmeta.do_notice\tmeta.if_in")
     
     def print_match(self, fpath, page, name, match):
-        print("Type: " + name)
-
+        source_name = os.path.splitext(os.path.basename(fpath))[0].translate(self.rule_enc)
         
-        
+        print ("\t".join([match,intel_types[name],source_name,"-","T","-"]))

--- a/output.py
+++ b/output.py
@@ -109,6 +109,7 @@ class OutputHandler_bro(OutputHandler):
         })
 
     def print_match(self, fpath, page, name, match):
+        # Assumes the following Bro intel file header: #fields indicator\tindicator_type\tmeta.source\tmeta.url\tmeta.do_notice\tmeta.if_in
         source_name = os.path.splitext(os.path.basename(fpath))[0].translate(self.rule_enc)
         
         if name in self.intel_types:

--- a/output.py
+++ b/output.py
@@ -114,4 +114,5 @@ class OutputHandler_bro(OutputHandler):
     def print_match(self, fpath, page, name, match):
         source_name = os.path.splitext(os.path.basename(fpath))[0].translate(self.rule_enc)
         
-        print ("\t".join([match,self.intel_types[name],source_name,"-","T","-"]))
+        if name in self.intel_types:
+            print ("\t".join([match,self.intel_types[name],source_name,"-","T","-"]))

--- a/output.py
+++ b/output.py
@@ -97,7 +97,7 @@ class OutputHandler_bro(OutputHandler):
     def __init__(self):
         self.rule_enc = ''.join(chr(c) if chr(c).isupper() or chr(c).islower() or chr(c).isdigit() else '_' for c in range(256))
 
-        intel_types = dict({
+        self.intel_types = dict({
             "IP": "Intel::ADDR",
             "URL": "Intel::URL",
             "Email": "Intel::EMAIL",
@@ -114,4 +114,4 @@ class OutputHandler_bro(OutputHandler):
     def print_match(self, fpath, page, name, match):
         source_name = os.path.splitext(os.path.basename(fpath))[0].translate(self.rule_enc)
         
-        print ("\t".join([match,intel_types[name],source_name,"-","T","-"]))
+        print ("\t".join([match,self.intel_types[name],source_name,"-","T","-"]))


### PR DESCRIPTION
Just added a new OutputHandler to allow output into the Bro Intel Framework format, as I have been making use of this to scrape APTNotes straight into Bro "signatures" and have found it pretty useful (with some aggressive whitelisting!).

Have tested this commit on the last 2 years worth of APTNotes PDF reports without issue. Debatable whether or not to add the Bro Intel file header, or to require the end-user to do so, as adding it using "print_header" would produce an invalid Intel file when parsing more than 1 input, due to recurring headers. 