### PR TITLE
Fix SyntaxError: Missing parentheses in call to 'print'

### DIFF
--- a/iocp/Output.py
+++ b/iocp/Output.py
@@ -107,7 +107,7 @@ class OutputHandler_yara(OutputHandler):
 		
 class OutputHandler_netflow(OutputHandler):
 	def __init__(self):
-		print "host 255.255.255.255"
+		print ("host 255.255.255.255")
 
 	def print_match(self, fpath, page, name, match):
 		data = {
@@ -115,4 +115,4 @@ class OutputHandler_netflow(OutputHandler):
 			'match': match
 		}
 		if data["type"] == "IP":
-			print " or host %s " % data["match"]
+			print (" or host %s " % data["match"])


### PR DESCRIPTION
This commit fixes the following issues
`  File "/home/<username>/.local/lib/python3.10/site-packages/iocp/Output.py", 
    line 110:    print "host 255.255.255.255"
    line 118:    print " or host %s " % data["match"]
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
SyntaxError: Missing parentheses in call to 'print'. Did you mean print(...)?`
